### PR TITLE
Add alerts reporting backend

### DIFF
--- a/REPORTES_IMPLEMENTACION.md
+++ b/REPORTES_IMPLEMENTACION.md
@@ -1,0 +1,460 @@
+# Modulo De Reportes
+
+## Objetivo
+
+Se reemplazo la idea de integrar Power BI por un modulo de reportes propio dentro del stack actual del proyecto:
+
+- `Backend`: `Node.js + Express + Sequelize + PostgreSQL`
+- `Frontend`: `React + Vite + TypeScript`
+- `Base de datos`: PostgreSQL en Neon
+- `Hosting`: Render para backend y vercel para frontend
+
+La meta fue construir una vista de reportes que:
+
+- consulte la base de datos real,
+- muestre metricas y graficas actualizadas,
+- permita filtrar por `estado`, `comuna`, `barrio` y `mes`,
+- no dependa de licencias de terceros.
+
+---
+
+### Libreria elegida
+
+Se uso `Recharts` en el frontend porque:
+
+- encaja bien con React,
+- soporta `LineChart`, `BarChart`, `PieChart`, `ResponsiveContainer`,
+- permite construir graficas sin meter una solucion pesada tipo BI.
+
+No se opto por graficas en `SVG` puro porque era mas costoso en tiempo y mantenimiento.
+
+---
+
+## Flujo General
+
+1. El usuario entra a la ruta `/reportes`.
+2. El frontend carga comunas y barrios para poblar filtros.
+3. El frontend llama al endpoint `GET /api/reports/alerts`.
+4. El backend consulta `alertas`, agrupa por estado, barrio, categoria y mes.
+5. El backend devuelve un payload listo para el dashboard.
+6. El frontend pinta:
+   - KPIs,
+   - linea por barrio,
+   - barras de resueltas,
+   - distribucion por estado,
+   - distribucion por categoria.
+7. La vista se refresca automaticamente cada 60 segundos.
+
+---
+
+## Implementacion Backend
+
+### 1. Nuevo endpoint de reportes
+
+Se creo un nuevo controlador en:
+
+- `src/controllers/reportController.ts`
+
+Responsabilidad:
+
+- validar filtros,
+- validar acceso por rol,
+- consultar alertas,
+- transformar datos,
+- devolver estructuras listas para graficar.
+
+### 2. Nueva ruta
+
+Se agrego:
+
+- `src/routes/reportRoutes.ts`
+
+Ruta expuesta:
+
+- `GET /api/reports/alerts`
+
+### 3. Registro en la app
+
+Se conecto la ruta en:
+
+- `src/app.ts`
+
+con:
+
+```ts
+app.use("/api/reports", reportRoutes);
+```
+
+### 4. Seguridad
+
+El endpoint usa `verifyToken` y adicionalmente valida el rol dentro del controlador:
+
+- `1 = admin`
+- `3 = JAC`
+
+Los demas usuarios reciben `403`.
+
+### 5. Filtros soportados
+
+Query params:
+
+- `id_estado`
+- `id_comuna`
+- `id_barrio`
+- `month` en formato `YYYY-MM`
+
+Ejemplo:
+
+```http
+GET /api/reports/alerts?id_estado=3&id_comuna=4&month=2026-03
+```
+
+### 6. Payload devuelto
+
+El endpoint devuelve:
+
+- `filters`: filtros aplicados,
+- `kpis`: totales principales,
+- `charts.alertasPorEstado`,
+- `charts.alertasPorBarrio`,
+- `charts.alertasPorCategoria`,
+- `charts.tendenciaMensual`,
+- `catalogos.estados`,
+- `catalogos.comunas`,
+- `catalogos.barrios`,
+- `generated_at`: fecha/hora de generacion.
+
+Ejemplo simplificado:
+
+```json
+{
+  "kpis": {
+    "total": 42,
+    "porAtender": 10,
+    "enProceso": 12,
+    "resueltas": 15,
+    "falsasAlertas": 5
+  },
+  "charts": {
+    "alertasPorEstado": [],
+    "alertasPorBarrio": [],
+    "alertasPorCategoria": [],
+    "tendenciaMensual": []
+  },
+  "generated_at": "2026-03-11T03:20:00.000Z"
+}
+```
+
+### 7. Correccion semantica en estadisticas
+
+En:
+
+- `src/controllers/statsController.ts`
+
+se corrigio la inconsistencia original:
+
+- antes `alertasAtendidas` contaba `id_estado = 1`,
+- ahora `alertasResueltas` cuenta `id_estado = 3`.
+
+Para no romper compatibilidad con el frontend existente, se dejo:
+
+- `alertasAtendidas: alertasResueltas`
+- `alertasResueltas`
+
+---
+
+## Implementacion Frontend
+
+Nota: el frontend vive en un repositorio hermano:
+
+- `../digital-alert-hub-frontend`
+
+### 1. Nueva vista de reportes
+
+Archivo principal:
+
+- `src/pages/Reportes/ReportesPage.tsx`
+
+Responsabilidad:
+
+- manejar filtros,
+- cargar datos,
+- refrescar automaticamente,
+- renderizar tarjetas y graficas.
+
+### 2. Tipos del modulo
+
+Se creo:
+
+- `src/types/Report.ts`
+
+Con los tipos:
+
+- `ReportFilters`
+- `ReportFilterState`
+- `AlertReportResponse`
+- items de series y catalogos
+
+### 3. Servicio HTTP
+
+Se creo:
+
+- `src/services/reportsService.ts`
+
+Responsabilidad:
+
+- consumir `/reports/alerts`,
+- enviar query params,
+- tipar la respuesta.
+
+### 4. Libreria agregada
+
+Se instalo:
+
+```bash
+npm install recharts
+```
+
+Se uso para:
+
+- `LineChart`
+- `BarChart`
+- `PieChart`
+- `Tooltip`
+- `Legend`
+- `ResponsiveContainer`
+
+### 5. Integracion con rutas protegidas
+
+En:
+
+- `src/App.tsx`
+
+la ruta `/reportes` se dejo protegida bajo `RoleRoute` para:
+
+- `admin`
+- `JAC`
+
+### 6. Auto refresh
+
+La vista recarga el reporte cada `60s` usando `setInterval`.
+
+No requiere recargar la pagina manualmente.
+
+Ventaja:
+
+- simple de mantener,
+- suficiente para un dashboard administrativo,
+- evita complejidad inicial de WebSockets o SSE.
+
+### 7. Filtros dinamicos
+
+La vista usa:
+
+- `locationsService.listComunas()`
+- `locationsService.listBarriosByComuna(idComuna)`
+
+Comportamiento:
+
+- si cambia comuna, se reinicia barrio,
+- si no hay comuna, barrio se deshabilita.
+
+### 8. Ajustes de UI
+
+La vista tuvo varias iteraciones visuales:
+
+1. version inicial tipo dashboard nativo,
+2. ajuste para parecerse mas al mockup,
+3. conservacion del fondo existente,
+4. alineacion con el patron visual de `Usuarios` y `Roles`,
+5. titulo en blanco para no perder contraste,
+6. color adicional en las graficas.
+
+Estado final:
+
+- mismo patron de contenedor grande que `Usuarios` y `Roles`,
+- breadcrumb con casa,
+- encabezado centrado,
+- tarjeta blanca principal,
+- filtros arriba,
+- KPIs al centro,
+- 4 graficas compactas.
+
+---
+
+## Archivos Backend Tocados
+
+- `src/app.ts`
+- `src/controllers/statsController.ts`
+- `src/controllers/reportController.ts`
+- `src/routes/reportRoutes.ts`
+
+## Archivos Frontend Tocados
+
+- `src/App.tsx`
+- `src/pages/Reportes/ReportesPage.tsx`
+- `src/pages/Reportes/ReportesPage.css`
+- `src/services/reportsService.ts`
+- `src/types/Report.ts`
+- `package.json`
+- `package-lock.json`
+
+---
+
+## Herramientas Utilizadas
+
+### Backend
+
+- `Express`
+- `Sequelize`
+- `PostgreSQL`
+- `Neon`
+- `TypeScript`
+
+### Frontend
+
+- `React`
+- `Vite`
+- `TypeScript`
+- `Axios`
+- `Recharts`
+
+### Infraestructura
+
+- `Neon` para base de datos PostgreSQL
+- `Render` para despliegue del backend/frontend
+
+---
+
+## Neon Y Render
+
+### Neon
+
+Se valido que Neon era adecuado para este escenario porque:
+
+- las consultas son agregaciones SQL relativamente livianas,
+- las evidencias no se guardan en la base, sino en Cloudinary,
+- el volumen principal es texto y metadatos, no binarios pesados.
+
+Se reviso que el uso de storage estaba bajo:
+
+- aproximadamente `0.03 / 0.5 GB`
+
+Eso significa que habia margen suficiente para seguir trabajando.
+
+### Render
+
+Render tambien es adecuado para este dashboard porque:
+
+- el backend expone endpoints REST normales,
+- el frontend solo consume JSON,
+- no depende de software externo tipo BI server.
+
+---
+
+## Validacion Tecnica
+
+### Backend
+
+Se valido con:
+
+```bash
+npx tsc --noEmit
+```
+
+### Frontend
+
+Se valido con:
+
+```bash
+npm run build
+```
+
+El frontend compilo correctamente.
+
+Se observaron advertencias no bloqueantes:
+
+- chunks grandes del bundle,
+- referencia a `Fondo_Formularios.png` en runtime.
+
+---
+
+## Como Funciona El Reporte
+
+### KPI 1
+
+- `Alertas por atender`
+- cuenta `id_estado = 1`
+
+### KPI 2
+
+- `Alertas solucionadas`
+- cuenta `id_estado = 3`
+
+### KPI 3
+
+- `Alertas en Proceso`
+- cuenta `id_estado = 2`
+
+### KPI 4
+
+- `Alertas Falsas`
+- cuenta `id_estado = 4`
+
+### Grafica 1
+
+- `Alertas por Barrio`
+- linea con top de barrios segun cantidad
+
+### Grafica 2
+
+- `Alertas Resueltas`
+- barras usando la serie mensual de resueltas
+
+### Grafica 3
+
+- `Alertas por Estado`
+- dona/pie con distribucion actual
+
+### Grafica 4
+
+- `Alertas por Categoria`
+- pie con categorias mas reportadas
+
+---
+
+## Ventajas Del Enfoque Elegido
+
+- sin costo adicional por licencias BI
+- control total sobre UI y permisos
+- integracion directa con autenticacion existente
+- filtros ajustados al modelo real de datos
+- facil de extender
+
+---
+
+## Posibles Mejoras Futuras
+
+1. Exportar a `CSV` o `PDF`.
+2. Agregar mas graficas:
+   - por prioridad,
+   - por usuario informante,
+   - por comuna.
+3. Agregar cache para consultas de reportes si crece el trafico.
+4. Implementar `SSE` o `WebSockets` si alguna vez se requiere tiempo real mas agresivo.
+5. Hacer carga diferida del modulo de reportes para bajar el tamaño del bundle.
+6. Crear datos demo controlados para visualizar mejor la distribucion de las graficas.
+
+---
+
+## Resumen Ejecutivo
+
+Se construyo un modulo de reportes propio, conectado a la base de datos real, con filtros y graficas interactivas, sin usar Power BI. El backend calcula agregaciones y el frontend las muestra con `Recharts`, protegido por rol y con refresco automatico.
+
+En terminos funcionales, ya existe una base util para:
+
+- mostrar indicadores,
+- explorar alertas por zona,
+- revisar distribucion por estado,
+- seguir tendencia mensual,
+- extender el dashboard segun nuevas necesidades.

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ dotenv.config();
 
 import authRoutes from "./routes/authRoutes";
 import alertRoutes from "./routes/alertRoutes";
+import reportRoutes from "./routes/reportRoutes";
 import statsRoutes from "./routes/statsRoutes";
 import profileRoutes from "./routes/profileRoutes";
 import userRoutes from "./routes/userRoutes";
@@ -37,6 +38,7 @@ app.use(passport.initialize()); // <-- NECESARIO PARA GOOGLE
 app.use("/api/auth", authRoutes);
 app.use("/api/auth", authGoogleRoutes); // <-- AÑADE Google Login (línea 20)
 app.use("/api/alerts", alertRoutes);
+app.use("/api/reports", reportRoutes);
 app.use("/api/stats", statsRoutes);
 app.use("/api/profile", profileRoutes);
 

--- a/src/controllers/reportController.ts
+++ b/src/controllers/reportController.ts
@@ -1,0 +1,280 @@
+import { Request, Response } from "express";
+import { Op, WhereOptions } from "sequelize";
+import Alerta from "../models/Alert";
+import Barrio from "../models/Barrio";
+import Comuna from "../models/Comuna";
+
+type ReportAlertRow = {
+  id_alerta: number;
+  id_estado: number;
+  id_comuna: number | null;
+  id_barrio: number | null;
+  categoria: string;
+  created_at: Date;
+};
+
+type MonthRange = {
+  value: string;
+  start: Date;
+  end: Date;
+};
+
+const ESTADO_LABEL_BY_ID: Record<number, string> = {
+  1: "Nueva",
+  2: "En Progreso",
+  3: "Resuelta",
+  4: "Falsa Alerta",
+};
+
+const parsePositiveIntQuery = (value: unknown): number | undefined | null => {
+  if (value === undefined || value === null || value === "") return undefined;
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+};
+
+const parseMonthQuery = (value: unknown): MonthRange | undefined | null => {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!/^\d{4}-\d{2}$/.test(trimmed)) return null;
+
+  const [yearText, monthText] = trimmed.split("-");
+  const year = Number(yearText);
+  const month = Number(monthText);
+
+  if (!Number.isInteger(year) || !Number.isInteger(month) || month < 1 || month > 12) {
+    return null;
+  }
+
+  const start = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0));
+
+  return {
+    value: trimmed,
+    start,
+    end,
+  };
+};
+
+const getMonthKey = (date: Date): string => {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+};
+
+const getMonthLabel = (monthKey: string): string => {
+  const [yearText, monthText] = monthKey.split("-");
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const date = new Date(Date.UTC(year, month - 1, 1));
+
+  return new Intl.DateTimeFormat("es-CO", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+};
+
+const buildRecentMonthKeys = (selectedMonth?: string): string[] => {
+  const anchor = selectedMonth
+    ? new Date(`${selectedMonth}-01T00:00:00.000Z`)
+    : new Date();
+  const months: string[] = [];
+
+  for (let offset = 5; offset >= 0; offset -= 1) {
+    const current = new Date(Date.UTC(anchor.getUTCFullYear(), anchor.getUTCMonth() - offset, 1));
+    months.push(getMonthKey(current));
+  }
+
+  return months;
+};
+
+export const getAlertReports = async (req: Request, res: Response) => {
+  try {
+    const userRole = Number((req as any).user?.rol);
+    if (userRole !== 1 && userRole !== 3) {
+      return res.status(403).json({ message: "No autorizado para consultar reportes" });
+    }
+
+    const idEstado = parsePositiveIntQuery(req.query.id_estado);
+    const idComuna = parsePositiveIntQuery(req.query.id_comuna);
+    const idBarrio = parsePositiveIntQuery(req.query.id_barrio);
+    const month = parseMonthQuery(req.query.month);
+
+    if (idEstado === null || idComuna === null || idBarrio === null) {
+      return res.status(400).json({
+        message: "Los filtros id_estado, id_comuna e id_barrio deben ser enteros positivos",
+      });
+    }
+
+    if (month === null) {
+      return res.status(400).json({
+        message: "El filtro month debe usar el formato YYYY-MM",
+      });
+    }
+
+    const where: WhereOptions = {};
+
+    if (idEstado !== undefined) {
+      where.id_estado = idEstado;
+    }
+
+    if (idComuna !== undefined) {
+      where.id_comuna = idComuna;
+    }
+
+    if (idBarrio !== undefined) {
+      where.id_barrio = idBarrio;
+    }
+
+    if (month) {
+      where.created_at = {
+        [Op.gte]: month.start,
+        [Op.lt]: month.end,
+      };
+    }
+
+    const alertas = (await Alerta.findAll({
+      where,
+      attributes: ["id_alerta", "id_estado", "id_comuna", "id_barrio", "categoria", "created_at"],
+      order: [["created_at", "ASC"]],
+      raw: true,
+    })) as ReportAlertRow[];
+
+    const comunaIds = Array.from(
+      new Set(
+        alertas
+          .map((alerta) => alerta.id_comuna)
+          .filter((value): value is number => Number.isInteger(value) && Number(value) > 0)
+      )
+    );
+
+    const barrioIds = Array.from(
+      new Set(
+        alertas
+          .map((alerta) => alerta.id_barrio)
+          .filter((value): value is number => Number.isInteger(value) && Number(value) > 0)
+      )
+    );
+
+    const [comunas, barrios] = await Promise.all([
+      comunaIds.length > 0
+        ? Comuna.findAll({
+            where: { id_comuna: comunaIds },
+            attributes: ["id_comuna", "nombre"],
+            raw: true,
+          })
+        : Promise.resolve([]),
+      barrioIds.length > 0
+        ? Barrio.findAll({
+            where: { id_barrio: barrioIds },
+            attributes: ["id_barrio", "nombre"],
+            raw: true,
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const countsByBarrio = new Map<string, number>();
+    const countsByCategoria = new Map<string, number>();
+    const countsByEstado = new Map<number, number>();
+    const barrioNameById = new Map<number, string>();
+    const monthKeys = buildRecentMonthKeys(month?.value);
+    const monthlyTrend = new Map<string, { total: number; resueltas: number }>();
+
+    for (const barrio of barrios as Array<{ id_barrio: number; nombre: string }>) {
+      barrioNameById.set(barrio.id_barrio, barrio.nombre);
+    }
+
+    for (const monthKey of monthKeys) {
+      monthlyTrend.set(monthKey, { total: 0, resueltas: 0 });
+    }
+
+    for (const alerta of alertas) {
+      const barrioLabel = alerta.id_barrio
+        ? barrioNameById.get(alerta.id_barrio) ?? `Barrio ${alerta.id_barrio}`
+        : "Sin barrio";
+      countsByBarrio.set(barrioLabel, (countsByBarrio.get(barrioLabel) ?? 0) + 1);
+
+      const categoriaLabel = alerta.categoria?.trim() || "Sin categoria";
+      countsByCategoria.set(categoriaLabel, (countsByCategoria.get(categoriaLabel) ?? 0) + 1);
+
+      countsByEstado.set(alerta.id_estado, (countsByEstado.get(alerta.id_estado) ?? 0) + 1);
+
+      const monthKey = getMonthKey(new Date(alerta.created_at));
+      if (!monthlyTrend.has(monthKey)) {
+        monthlyTrend.set(monthKey, { total: 0, resueltas: 0 });
+      }
+
+      const currentMonth = monthlyTrend.get(monthKey)!;
+      currentMonth.total += 1;
+      if (alerta.id_estado === 3) {
+        currentMonth.resueltas += 1;
+      }
+    }
+
+    return res.json({
+      filters: {
+        id_estado: idEstado ?? null,
+        id_comuna: idComuna ?? null,
+        id_barrio: idBarrio ?? null,
+        month: month?.value ?? null,
+      },
+      kpis: {
+        total: alertas.length,
+        porAtender: countsByEstado.get(1) ?? 0,
+        enProceso: countsByEstado.get(2) ?? 0,
+        resueltas: countsByEstado.get(3) ?? 0,
+        falsasAlertas: countsByEstado.get(4) ?? 0,
+      },
+      charts: {
+        alertasPorEstado: Object.entries(ESTADO_LABEL_BY_ID).map(([id, label]) => ({
+          id_estado: Number(id),
+          label,
+          total: countsByEstado.get(Number(id)) ?? 0,
+        })),
+        alertasPorBarrio: Array.from(countsByBarrio.entries())
+          .map(([label, total]) => ({ label, total }))
+          .sort((a, b) => b.total - a.total || a.label.localeCompare(b.label, "es")),
+        alertasPorCategoria: Array.from(countsByCategoria.entries())
+          .map(([label, total]) => ({ label, total }))
+          .sort((a, b) => b.total - a.total || a.label.localeCompare(b.label, "es")),
+        tendenciaMensual: Array.from(monthlyTrend.entries())
+          .sort(([monthA], [monthB]) => monthA.localeCompare(monthB))
+          .map(([monthKey, values]) => ({
+            month: monthKey,
+            label: getMonthLabel(monthKey),
+            total: values.total,
+            resueltas: values.resueltas,
+          })),
+      },
+      catalogos: {
+        estados: Object.entries(ESTADO_LABEL_BY_ID).map(([id, label]) => ({
+          id_estado: Number(id),
+          label,
+        })),
+        comunas: (comunas as Array<{ id_comuna: number; nombre: string }>)
+          .map((comuna) => ({
+            id_comuna: comuna.id_comuna,
+            nombre: comuna.nombre,
+          }))
+          .sort((a, b) => a.nombre.localeCompare(b.nombre, "es")),
+        barrios: (barrios as Array<{ id_barrio: number; nombre: string }>)
+          .map((barrio) => ({
+            id_barrio: barrio.id_barrio,
+            nombre: barrio.nombre,
+          }))
+          .sort((a, b) => a.nombre.localeCompare(b.nombre, "es")),
+      },
+      generated_at: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Error al obtener reporte de alertas:", error);
+    return res.status(500).json({ message: "Error al obtener reporte de alertas" });
+  }
+};

--- a/src/controllers/statsController.ts
+++ b/src/controllers/statsController.ts
@@ -7,17 +7,18 @@ export const getStats = async (req: Request, res: Response) => {
 
     const ciudadanos = await Usuario.count();
     const alertasTotales = await Alerta.count();
-    const alertasAtendidas = await Alerta.count({
-      where: { id_estado: 1 }
+    const alertasResueltas = await Alerta.count({
+      where: { id_estado: 3 }
     });
     const alertasPendientes = await Alerta.count({
-      where: { id_estado: 2 }
+      where: { id_estado: 1 }
     });
 
     return res.json({
       ciudadanos,
       alertasTotales,
-      alertasAtendidas,
+      alertasAtendidas: alertasResueltas,
+      alertasResueltas,
       alertasPendientes
     });
   } catch (error) {

--- a/src/routes/reportRoutes.ts
+++ b/src/routes/reportRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { getAlertReports } from "../controllers/reportController";
+import { verifyToken } from "../middleware/authMiddleware";
+
+const router = Router();
+
+router.get("/alerts", verifyToken, getAlertReports);
+
+export default router;


### PR DESCRIPTION
- Se crea `GET /api/reports/alerts`
- Se agregan filtros por:
  - `id_estado`
  - `id_comuna`
  - `id_barrio`
  - `month` (`YYYY-MM`)
- Se devuelven en una sola respuesta:
  - `kpis`
  - `charts.alertasPorEstado`
  - `charts.alertasPorBarrio`
  - `charts.alertasPorCategoria`
  - `charts.tendenciaMensual`
  - `catalogos`
  - `generated_at`
- Se restringe el acceso a roles `admin` y `JAC`


## Archivos relevantes
- `src/controllers/reportController.ts`
- `src/routes/reportRoutes.ts`
- `src/app.ts`
- `src/controllers/statsController.ts`
- `REPORTES_IMPLEMENTACION.md`

## Validación
- `npx tsc --noEmit`

## Impacto
- No rompe el frontend actual
- Habilita el nuevo dashboard de reportes consumiendo datos reales desde la base