### PR TITLE
fix(auth): return session token alongside cookie

### DIFF
--- a/src/controllers/auth/authController.ts
+++ b/src/controllers/auth/authController.ts
@@ -37,6 +37,7 @@ export const login = async (req: Request, res: Response): Promise<void> => {
   setSessionCookie(req, res, result.token);
   res.json({
     message: result.message,
+    token: result.token,
     user: result.user,
   });
 };
@@ -47,7 +48,10 @@ export const exchangeGoogleCode = async (
 ): Promise<void> => {
   const result = await exchangeGoogleCallbackCode(req.body ?? {});
   setSessionCookie(req, res, result.token);
-  res.json({ message: "Sesion iniciada correctamente" });
+  res.json({
+    message: "Sesion iniciada correctamente",
+    token: result.token,
+  });
 };
 
 export const getSession = async (


### PR DESCRIPTION
## Resumen

Este PR ajusta el flujo de autenticación para que el backend siga emitiendo la cookie de sesión actual, pero además devuelva el `token` en las respuestas de login y de intercambio del callback de Google.

## Motivación

Detectamos que algunos celulares no persisten correctamente la cookie cross-site entre `vercel.app` y `onrender.com`, lo que hace que el usuario seleccione su cuenta de Google pero termine redirigido al home sin sesión activa.

Con este cambio no se elimina la cookie actual. Se agrega un fallback compatible para que el frontend pueda autenticarse también por `Bearer token` cuando el navegador móvil bloquee la cookie.

## Cambios

- `POST /api/auth/login` ahora responde también con `token`
- `POST /api/auth/google/exchange` ahora responde también con `token`
- se mantiene la cookie `HttpOnly` sin cambios en su emisión


